### PR TITLE
add rust ci and lint makefile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,55 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust nightly
+      run: rustup install nightly
+
+    - name: Install rustfmt for nightly
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt
+
+    - name: Run rustfmt
+      run: cargo +nightly fmt -- --check
+
+  cargo-clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Run Clippy
+      run: cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build
+      run: cargo build --verbose
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      run: cargo test --workspace -- --nocapture

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := help
+
+##@ Help
+.PHONY: help
+help: # Display this help.
+	@awk 'BEGIN {FS = ":.*#"; printf "Usage:\n  make \033[34m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?#/ { printf "  \033[34m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) }' $(MAKEFILE_LIST)
+
+##@ Others
+.PHONY: clean
+clean: # Run `cargo clean`.
+	cargo clean
+
+.PHONY: lint
+lint: # Run `clippy` and `rustfmt`.
+	cargo +nightly fmt --all
+	cargo clippy --all --all-targets --all-features --no-deps -- --deny warnings

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+reorder_imports  = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+wrap_comments = true
+comment_width = 100
+normalize_comments = true
+format_code_in_doc_comments = true


### PR DESCRIPTION
We are adding rust code to auto generate test data it would be nice if we then had a ci for rust and a makefile for linting. We are adding rust code in this PR https://github.com/ethereum/portal-spec-tests/pull/32